### PR TITLE
fixed java package install for yum from 1.7.0 to 1.8.0

### DIFF
--- a/tasks/linux/install-dependencies-yum.yml
+++ b/tasks/linux/install-dependencies-yum.yml
@@ -5,9 +5,9 @@
   ignore_errors: yes
   become: yes
 
-- name: Install package 'java-1.7.0-openjdk'
+- name: Install package 'java-1.8.0-openjdk'
   yum:
-    pkg: java-1.7.0-openjdk
+    pkg: java-1.8.0-openjdk
     state: present
   register: java_install
   when: which_java_cmd.rc != 0

--- a/tasks/linux/remove-dependencies-yum.yml
+++ b/tasks/linux/remove-dependencies-yum.yml
@@ -1,7 +1,7 @@
 ---
-- name: Remove package 'java-1.7.0-openjdk'
+- name: Remove package 'java-1.8.0-openjdk'
   yum:
-    pkg: java-1.7.0-openjdk
+    pkg: java-1.8.0-openjdk
     state: absent
   ignore_errors: yes
   when: not java_install | skipped


### PR DESCRIPTION
As per the Server role, the installers require java 1.8.0. On a server with no java, the role installs version 1.7.0 which breaks the ability for the installer to work.
With 1.8.0 all works as expected